### PR TITLE
Ensure finished progress timestamps sync correctly

### DIFF
--- a/ShelfPlayback/PlaybackReporter.swift
+++ b/ShelfPlayback/PlaybackReporter.swift
@@ -187,7 +187,10 @@ private extension PlaybackReporter {
         }
         
         do {
-            try await PersistenceManager.shared.progress.update(itemID, currentTime: currentTime, duration: duration, notifyServer: false)
+            try await PersistenceManager.shared.progress.update(itemID,
+                                                                currentTime: currentTime,
+                                                                duration: duration,
+                                                                notifyServer: force)
         } catch {
             logger.warning("Cannot update progress: \(error).")
         }

--- a/ShelfPlayback/PlaybackReporter.swift
+++ b/ShelfPlayback/PlaybackReporter.swift
@@ -187,10 +187,7 @@ private extension PlaybackReporter {
         }
         
         do {
-            try await PersistenceManager.shared.progress.update(itemID,
-                                                                currentTime: currentTime,
-                                                                duration: duration,
-                                                                notifyServer: force)
+            try await PersistenceManager.shared.progress.update(itemID, currentTime: currentTime, duration: duration, notifyServer: force)
         } catch {
             logger.warning("Cannot update progress: \(error).")
         }

--- a/ShelfPlayerKit/Persistence/ProgressSubsystem.swift
+++ b/ShelfPlayerKit/Persistence/ProgressSubsystem.swift
@@ -525,7 +525,7 @@ public extension PersistenceManager.ProgressSubsystem {
                                      currentTime: payload.currentTime ?? 0,
                                      startedAt: payload.startedAt != nil ? Date(timeIntervalSince1970: Double(payload.startedAt!) / 1000) : nil,
                                      lastUpdate: payload.lastUpdate != nil ? Date(timeIntervalSince1970: Double(payload.lastUpdate!) / 1000) : .now,
-                                     finishedAt: payload.lastUpdate != nil ? Date(timeIntervalSince1970: Double(payload.lastUpdate!) / 1000) : nil,
+                                     finishedAt: payload.finishedAt != nil ? Date(timeIntervalSince1970: Double(payload.finishedAt!) / 1000) : nil,
                                      status: .synchronized)
             }
             // }


### PR DESCRIPTION
## Summary
- trigger a server-bound progress update when the playback reporter performs its final sync
- correct the finishedAt field when creating local progress entities from server payloads

## Testing
- not run (iOS project; xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3f31cdee08325b3e75d64a1e8862e